### PR TITLE
Add basic tests for modules

### DIFF
--- a/product_blueprint_manager/tests/__init__.py
+++ b/product_blueprint_manager/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_blueprint

--- a/product_blueprint_manager/tests/test_product_blueprint.py
+++ b/product_blueprint_manager/tests/test_product_blueprint.py
@@ -1,0 +1,37 @@
+import base64
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProductBlueprint(TransactionCase):
+    def test_extract_svg_formulas_creates_names(self):
+        product = self.env["product.template"].create(
+            {
+                "name": "Test product",
+                "type": "consu",
+            }
+        )
+        svg = (
+            "<svg xmlns='http://www.w3.org/2000/svg'>"
+            "<text id='f1' class='odoo-formula' style='fill:#ff0000;font-size:14px'>"
+            "{{LENGTH}}</text>"
+            "</svg>"
+        )
+        blueprint = self.env["product.blueprint"].create(
+            {
+                "name": "Blueprint 1",
+                "file": base64.b64encode(svg.encode()),
+                "product_id": product.id,
+            }
+        )
+        blueprint._extract_svg_formulas()
+        formula_name = self.env["product.blueprint.formula.name"].search(
+            [
+                ("name", "=", "LENGTH"),
+                ("blueprint_id", "=", blueprint.id),
+            ]
+        )
+        self.assertEqual(len(formula_name), 1)
+        self.assertEqual(formula_name.svg_element_id, "f1")
+        self.assertEqual(formula_name.fill_color, "#ff0000")
+        self.assertEqual(formula_name.font_size, "14px")

--- a/product_configurator_attribute_price/tests/__init__.py
+++ b/product_configurator_attribute_price/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_price_formula

--- a/product_configurator_attribute_price/tests/test_price_formula.py
+++ b/product_configurator_attribute_price/tests/test_price_formula.py
@@ -1,0 +1,45 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestPriceFormula(TransactionCase):
+    def test_calculate_price_increment_formula(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Length",
+                "price_formula": "custom_value * 2",
+                "price_extra": 0,
+            }
+        )
+        self.assertEqual(ptav.calculate_price_increment(10, 0), 20)
+
+    def test_calculate_price_increment_no_formula(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Width",
+                "price_formula": False,
+                "price_extra": 5,
+            }
+        )
+        self.assertEqual(ptav.calculate_price_increment(10, 0), 5)
+
+    def test_calculate_price_increment_negative(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Size",
+                "price_formula": "custom_value - 50",
+                "price_extra": 0,
+            }
+        )
+        self.assertEqual(ptav.calculate_price_increment(10, 0), 0)
+
+    def test_calculate_price_increment_error(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Broken",
+                "price_formula": "custom_value /",
+                "price_extra": 0,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            ptav.calculate_price_increment(10, 0)


### PR DESCRIPTION
## Summary
- add tests for blueprint SVG formulas
- cover price calculation formulas

## Testing
- `pre-commit run --files product_blueprint_manager/tests/__init__.py product_blueprint_manager/tests/test_product_blueprint.py product_configurator_attribute_price/tests/__init__.py product_configurator_attribute_price/tests/test_price_formula.py`
- `pytest` *(fails: AssertionError: Invalid import ... should start with 'odoo.addons')*


------
https://chatgpt.com/codex/tasks/task_e_688d8d64f638832fba248cbca4801fa0