### PR TITLE
[ADD] enhance tests for Odoo 18 compatibility

### DIFF
--- a/auto_journal_by_company/tests/test_auto_journal.py
+++ b/auto_journal_by_company/tests/test_auto_journal.py
@@ -1,28 +1,25 @@
-from odoo.tests import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestAutoJournalByCompany(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.company = self.env["res.company"].create(
-            {
-                "name": "Empresa de Test",
-            }
-        )
-        self.journal_sale = self.env["account.journal"].create(
+class TestAutoJournalByCompany(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].create({"name": "Empresa de Test"})
+        cls.journal_sale = cls.env["account.journal"].create(
             {
                 "name": "Ventas Test",
                 "type": "sale",
                 "code": "VT",
-                "company_id": self.company.id,
+                "company_id": cls.company.id,
             }
         )
-        self.journal_purchase = self.env["account.journal"].create(
+        cls.journal_purchase = cls.env["account.journal"].create(
             {
                 "name": "Compras Test",
                 "type": "purchase",
                 "code": "CT",
-                "company_id": self.company.id,
+                "company_id": cls.company.id,
             }
         )
 
@@ -50,4 +47,40 @@ class TestAutoJournalByCompany(TransactionCase):
             move.journal_id,
             self.journal_purchase,
             "No se asignó correctamente el diario de compras",
+        )
+
+    def test_onchange_auto_assign_journal(self):
+        move = self.env["account.move"].new(
+            {
+                "move_type": "out_invoice",
+                "company_id": self.company.id,
+            }
+        )
+        move._onchange_company_or_type()
+        self.assertEqual(
+            move.journal_id,
+            self.journal_sale,
+            "El onchange no asignó el diario de ventas",
+        )
+
+    def test_create_respects_existing_journal(self):
+        other_journal = self.env["account.journal"].create(
+            {
+                "name": "Misceláneo",
+                "type": "general",
+                "code": "MI",
+                "company_id": self.company.id,
+            }
+        )
+        move = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "company_id": self.company.id,
+                "journal_id": other_journal.id,
+            }
+        )
+        self.assertEqual(
+            move.journal_id,
+            other_journal,
+            "Se reemplazó un diario ya definido",
         )

--- a/product_blueprint_manager/tests/test_product_blueprint.py
+++ b/product_blueprint_manager/tests/test_product_blueprint.py
@@ -1,16 +1,21 @@
 import base64
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestProductBlueprint(TransactionCase):
-    def test_extract_svg_formulas_creates_names(self):
-        product = self.env["product.template"].create(
+class TestProductBlueprint(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env["product.template"].create(
             {
                 "name": "Test product",
                 "type": "consu",
             }
         )
+        cls.partner = cls.env["res.partner"].create({"name": "Partner"})
+
+    def test_extract_svg_formulas_creates_names(self):
         svg = (
             "<svg xmlns='http://www.w3.org/2000/svg'>"
             "<text id='f1' class='odoo-formula' style='fill:#ff0000;font-size:14px'>"
@@ -21,7 +26,7 @@ class TestProductBlueprint(TransactionCase):
             {
                 "name": "Blueprint 1",
                 "file": base64.b64encode(svg.encode()),
-                "product_id": product.id,
+                "product_id": self.product.id,
             }
         )
         blueprint._extract_svg_formulas()
@@ -35,3 +40,61 @@ class TestProductBlueprint(TransactionCase):
         self.assertEqual(formula_name.svg_element_id, "f1")
         self.assertEqual(formula_name.fill_color, "#ff0000")
         self.assertEqual(formula_name.font_size, "14px")
+
+    def test_blueprint_applies_only_with_matching_attribute_value(self):
+        attribute = self.env["product.attribute"].create({"name": "Size"})
+        value_s = self.env["product.attribute.value"].create(
+            {"name": "S", "attribute_id": attribute.id}
+        )
+        value_l = self.env["product.attribute.value"].create(
+            {"name": "L", "attribute_id": attribute.id}
+        )
+        self.product.attribute_line_ids = [
+            (
+                0,
+                0,
+                {
+                    "attribute_id": attribute.id,
+                    "value_ids": [(6, 0, [value_s.id, value_l.id])],
+                },
+            )
+        ]
+        variant_s = self.product.product_variant_ids.filtered(
+            lambda p: value_s
+            in p.product_template_attribute_value_ids.mapped(
+                "product_attribute_value_id"
+            )
+        )[0]
+        variant_l = self.product.product_variant_ids.filtered(
+            lambda p: value_l
+            in p.product_template_attribute_value_ids.mapped(
+                "product_attribute_value_id"
+            )
+        )[0]
+        svg = "<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+        self.env["product.blueprint"].create(
+            {
+                "name": "Blueprint 2",
+                "file": base64.b64encode(svg.encode()),
+                "product_id": self.product.id,
+                "attribute_filter_id": attribute.id,
+                "attribute_value_ids": [(6, 0, [value_s.id])],
+            }
+        )
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        line_s = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": variant_s.id,
+                "product_uom_qty": 1,
+            }
+        )
+        line_l = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": variant_l.id,
+                "product_uom_qty": 1,
+            }
+        )
+        self.assertTrue(line_s._get_evaluated_blueprint())
+        self.assertEqual(line_l._get_evaluated_blueprint(), [])

--- a/product_configurator_attribute_price/tests/test_price_formula.py
+++ b/product_configurator_attribute_price/tests/test_price_formula.py
@@ -1,8 +1,8 @@
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestPriceFormula(TransactionCase):
+class TestPriceFormula(SavepointCase):
     def test_calculate_price_increment_formula(self):
         ptav = self.env["product.template.attribute.value"].new(
             {
@@ -43,3 +43,23 @@ class TestPriceFormula(TransactionCase):
         )
         with self.assertRaises(ValidationError):
             ptav.calculate_price_increment(10, 0)
+
+    def test_calculate_price_increment_math_functions(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Root",
+                "price_formula": "sqrt(custom_value)",
+                "price_extra": 0,
+            }
+        )
+        self.assertEqual(ptav.calculate_price_increment(9, 0), 3)
+
+    def test_calculate_price_increment_uses_price_so_far(self):
+        ptav = self.env["product.template.attribute.value"].new(
+            {
+                "name": "Percent",
+                "price_formula": "price_so_far * 0.1",
+                "price_extra": 0,
+            }
+        )
+        self.assertEqual(ptav.calculate_price_increment(10, 100), 10)


### PR DESCRIPTION
## Summary
- migrate module tests to SavepointCase and add new test scenarios
- cover price formula math/price_so_far cases
- ensure blueprints respect attribute filters in sale lines

## Testing
- `pre-commit run --files auto_journal_by_company/tests/test_auto_journal.py product_blueprint_manager/tests/test_product_blueprint.py product_configurator_attribute_price/tests/test_price_formula.py`
- `pytest auto_journal_by_company/tests/test_auto_journal.py product_blueprint_manager/tests/test_product_blueprint.py product_configurator_attribute_price/tests/test_price_formula.py` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_688e833af82c832fb36dca7012c15f7a