### PR TITLE
Add blueprint condition model

### DIFF
--- a/product_blueprint_manager/models/__init__.py
+++ b/product_blueprint_manager/models/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     product_blueprint,
+    product_blueprint_condition,
     product_blueprint_formula,
     product_blueprint_formula_name,
     product_hooks,

--- a/product_blueprint_manager/models/product_blueprint_condition.py
+++ b/product_blueprint_manager/models/product_blueprint_condition.py
@@ -1,0 +1,60 @@
+from odoo import api, fields, models
+
+
+class ProductBlueprintCondition(models.Model):
+    _name = "product.blueprint.condition"
+    _description = "Condición del Plano de Producto"
+
+    blueprint_id = fields.Many2one(
+        "product.blueprint",
+        string="Plano",
+        required=True,
+        ondelete="cascade",
+    )
+    attribute_id = fields.Many2one(
+        "product.attribute",
+        string="Atributo",
+        required=True,
+    )
+    value_ids = fields.Many2many(
+        "product.attribute.value",
+        string="Valores",
+    )
+    product_id = fields.Many2one(
+        "product.template",
+        string="Producto",
+        related="blueprint_id.product_id",
+        readonly=True,
+    )
+
+    @api.onchange("blueprint_id")
+    def _onchange_blueprint_id(self):
+        if self.blueprint_id and self.blueprint_id.product_id:
+            attribute_ids = (
+                self.blueprint_id.product_id.attribute_line_ids.mapped(
+                    "attribute_id"
+                ).ids
+            )
+            return {"domain": {"attribute_id": [("id", "in", attribute_ids)]}}
+        self.attribute_id = False
+        self.value_ids = False
+        return {
+            "domain": {
+                "attribute_id": [("id", "=", False)],
+                "value_ids": [("id", "=", False)],
+            }
+        }
+
+    @api.onchange("attribute_id")
+    def _onchange_attribute_id(self):
+        if self.attribute_id:
+            return {
+                "domain": {
+                    "value_ids": [
+                        ("attribute_id", "=", self.attribute_id.id)
+                    ]
+                }
+            }
+        self.value_ids = False
+        return {"domain": {"value_ids": [("id", "=", False)]}}
+


### PR DESCRIPTION
## Summary
- add model to manage blueprint conditions with product/attribute/value links
- register blueprint condition model

## Testing
- `pip install lxml -q`
- `pip install odoo -q` *(fails: No matching distribution)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_68936681d9a8832fb21d9a1acdf754e4