### PR TITLE
refactor: test blueprint conditional logic

### DIFF
--- a/product_blueprint_manager/tests/test_blueprint_filtering.py
+++ b/product_blueprint_manager/tests/test_blueprint_filtering.py
@@ -10,7 +10,7 @@ class TestBlueprintFiltering(TransactionCase):
         AttributeValue = self.env["product.attribute.value"]
         Blueprint = self.env["product.blueprint"]
 
-        # Crear atributo y valores
+        # Crear atributos y valores
         self.attr_vidrio = Attribute.create(
             {
                 "name": "Vidrio",
@@ -29,8 +29,26 @@ class TestBlueprintFiltering(TransactionCase):
                 "attribute_id": self.attr_vidrio.id,
             }
         )
+        self.attr_acabado = Attribute.create(
+            {
+                "name": "Acabado",
+                "create_variant": "no_variant",
+            }
+        )
+        self.val_pulido = AttributeValue.create(
+            {
+                "name": "Pulido",
+                "attribute_id": self.attr_acabado.id,
+            }
+        )
+        self.val_mate = AttributeValue.create(
+            {
+                "name": "Mate",
+                "attribute_id": self.attr_acabado.id,
+            }
+        )
 
-        # Crear producto con atributo
+        # Crear producto con ambos atributos
         self.product_template = ProductTemplate.create(
             {
                 "name": "Mampara Test",
@@ -44,20 +62,38 @@ class TestBlueprintFiltering(TransactionCase):
                                 (6, 0, [self.val_transp.id, self.val_carglas.id])
                             ],
                         },
-                    )
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr_acabado.id,
+                            "value_ids": [
+                                (6, 0, [self.val_pulido.id, self.val_mate.id])
+                            ],
+                        },
+                    ),
                 ],
             }
         )
         self.product = self.product_template.product_variant_ids[0]
 
-        # Crear blueprint con filtro: requiere "Transparente"
+        # Crear blueprint con condición: requiere "Transparente"
         self.blueprint = Blueprint.create(
             {
                 "name": "Plano Transparente",
                 "type": "purchase",
                 "product_tmpl_id": self.product_template.id,
-                "attribute_filter_id": self.attr_vidrio.id,
-                "attribute_filter_value_ids": [(6, 0, [self.val_transp.id])],
+                "blueprint_condition_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr_vidrio.id,
+                            "value_ids": [(6, 0, [self.val_transp.id])],
+                        },
+                    )
+                ],
                 "svg_file": b"<svg></svg>",
             }
         )
@@ -70,11 +106,9 @@ class TestBlueprintFiltering(TransactionCase):
                 "product_template_attribute_value_ids": [(6, 0, [self.val_transp.id])],
             }
         )
-        selected = [v.name for v in order_line.product_template_attribute_value_ids]
-        required = [v.name for v in self.blueprint.attribute_filter_value_ids]
-        self.assertTrue(
-            all(val in selected for val in required), "El plano debería incluirse"
-        )
+        result = order_line._get_evaluated_blueprint(type_blueprint="purchase")
+        names = [b["blueprint_name"] for b in result]
+        self.assertIn("Plano Transparente", names, "El plano debería incluirse")
 
     def test_blueprint_is_excluded_when_attribute_does_not_match(self):
         # Simula línea con valor "Impreso Carglas"
@@ -84,8 +118,86 @@ class TestBlueprintFiltering(TransactionCase):
                 "product_template_attribute_value_ids": [(6, 0, [self.val_carglas.id])],
             }
         )
-        selected = [v.name for v in order_line.product_template_attribute_value_ids]
-        required = [v.name for v in self.blueprint.attribute_filter_value_ids]
-        self.assertFalse(
-            all(val in selected for val in required), "El plano no debe incluirse"
+        result = order_line._get_evaluated_blueprint(type_blueprint="purchase")
+        names = [b["blueprint_name"] for b in result]
+        self.assertNotIn("Plano Transparente", names, "El plano no debe incluirse")
+
+    def test_blueprint_without_conditions_applies(self):
+        blueprint = self.env["product.blueprint"].create(
+            {
+                "name": "Plano Libre",
+                "type": "purchase",
+                "product_tmpl_id": self.product_template.id,
+                "blueprint_condition_ids": [],
+                "svg_file": b"<svg></svg>",
+            }
+        )
+        order_line = self.env["sale.order.line"].new(
+            {
+                "product_id": self.product.id,
+                "product_template_attribute_value_ids": [(6, 0, [self.val_carglas.id])],
+            }
+        )
+        result = order_line._get_evaluated_blueprint(type_blueprint="purchase")
+        names = [b["blueprint_name"] for b in result]
+        self.assertIn(blueprint.name, names, "El plano sin condiciones debe incluirse")
+
+    def test_blueprint_with_multiple_conditions(self):
+        blueprint = self.env["product.blueprint"].create(
+            {
+                "name": "Plano Múltiple",
+                "type": "purchase",
+                "product_tmpl_id": self.product_template.id,
+                "blueprint_condition_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr_vidrio.id,
+                            "value_ids": [(6, 0, [self.val_transp.id])],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr_acabado.id,
+                            "value_ids": [(6, 0, [self.val_pulido.id])],
+                        },
+                    ),
+                ],
+                "svg_file": b"<svg></svg>",
+            }
+        )
+        line_ok = self.env["sale.order.line"].new(
+            {
+                "product_id": self.product.id,
+                "product_template_attribute_value_ids": [
+                    (6, 0, [self.val_transp.id, self.val_pulido.id])
+                ],
+            }
+        )
+        names_ok = [
+            b["blueprint_name"]
+            for b in line_ok._get_evaluated_blueprint(type_blueprint="purchase")
+        ]
+        self.assertIn(
+            blueprint.name,
+            names_ok,
+            "El plano debería incluirse con todas las condiciones",
+        )
+        line_fail = self.env["sale.order.line"].new(
+            {
+                "product_id": self.product.id,
+                "product_template_attribute_value_ids": [(6, 0, [self.val_transp.id])],
+            }
+        )
+        names_fail = [
+            b["blueprint_name"]
+            for b in line_fail._get_evaluated_blueprint(type_blueprint="purchase")
+        ]
+        self.assertNotIn(
+            blueprint.name,
+            names_fail,
+            "El plano no debe incluirse si falta una condición",
         )

--- a/product_blueprint_manager/tests/test_blueprint_filters_and_types.py
+++ b/product_blueprint_manager/tests/test_blueprint_filters_and_types.py
@@ -27,17 +27,27 @@ class TestBlueprintFilters(TransactionCase):
             {
                 "name": "Plano Solo Transparente",
                 "product_tmpl_id": tmpl.id,
-                "attribute_filter_id": attr.id,
-                "attribute_filter_value_ids": [(6, 0, [val.id])],
+                "blueprint_condition_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": attr.id,
+                            "value_ids": [(6, 0, [val.id])],
+                        },
+                    )
+                ],
                 "svg_file": b"<svg></svg>",
                 "type": "manufacturing",
             }
         )
         product = tmpl.product_variant_id
-        line = self.env["sale.order.line"].new(  # noqa: F841
+        line = self.env["sale.order.line"].new(
             {
                 "product_id": product.id,
                 "product_template_attribute_value_ids": [(6, 0, [val.id])],
             }
         )
-        self.assertIn(val.name, [v.name for v in blueprint.attribute_filter_value_ids])
+        evaluated = line._get_evaluated_blueprint()
+        names = [b["blueprint_name"] for b in evaluated]
+        self.assertIn(blueprint.name, names, "El plano debería incluirse")

--- a/product_blueprint_manager/tests/test_product_blueprint.py
+++ b/product_blueprint_manager/tests/test_product_blueprint.py
@@ -27,6 +27,7 @@ class TestProductBlueprint(SavepointCase):
                 "name": "Blueprint 1",
                 "file": base64.b64encode(svg.encode()),
                 "product_id": self.product.id,
+                "blueprint_condition_ids": [],
             }
         )
         blueprint._extract_svg_formulas()
@@ -77,8 +78,16 @@ class TestProductBlueprint(SavepointCase):
                 "name": "Blueprint 2",
                 "file": base64.b64encode(svg.encode()),
                 "product_id": self.product.id,
-                "attribute_filter_id": attribute.id,
-                "attribute_value_ids": [(6, 0, [value_s.id])],
+                "blueprint_condition_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": attribute.id,
+                            "value_ids": [(6, 0, [value_s.id])],
+                        },
+                    )
+                ],
             }
         )
         order = self.env["sale.order"].create({"partner_id": self.partner.id})

--- a/product_blueprint_manager/tests/test_product_blueprint_models.py
+++ b/product_blueprint_manager/tests/test_product_blueprint_models.py
@@ -10,6 +10,7 @@ class TestProductBlueprintModels(TransactionCase):
                 "product_tmpl_id": self.env.ref(
                     "product.product_product_4_product_template"
                 ).id,
+                "blueprint_condition_ids": [],
                 "svg_file": b"""<svg><text class='odoo-formula' aria-label=
                 'Ancho'>0</text></svg>""",
                 "type": "manufacturing",
@@ -26,6 +27,7 @@ class TestProductBlueprintModels(TransactionCase):
                 "product_tmpl_id": self.env.ref(
                     "product.product_product_4_product_template"
                 ).id,
+                "blueprint_condition_ids": [],
                 "svg_file": b"""<svg><text class='odoo-formula'
                   aria-label='Valor1'>0</text></svg>""",
                 "type": "manufacturing",


### PR DESCRIPTION
## Summary
- refactor blueprint test setup to create conditions through `blueprint_condition_ids`
- validate blueprint inclusion/exclusion by evaluating full condition sets
- add tests for blueprints without conditions and with multiple simultaneous conditions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pre-commit run --files product_blueprint_manager/tests/test_product_blueprint_models.py product_blueprint_manager/tests/test_product_blueprint.py product_blueprint_manager/tests/test_blueprint_filters_and_types.py product_blueprint_manager/tests/test_blueprint_filtering.py`

------
https://chatgpt.com/codex/tasks/task_e_6893668af828832f984f5bfb056ac07c