### PR TITLE
feat: add product blueprint condition views

### DIFF
--- a/product_blueprint_manager/__manifest__.py
+++ b/product_blueprint_manager/__manifest__.py
@@ -22,6 +22,7 @@
         "security/ir.model.access.csv",
         "reports/report_paperformat.xml",
         "data/blueprint_report_data.xml",
+        "views/product_blueprint_condition_views.xml",
         "views/sale_order_views.xml",
         "views/product_views.xml",
         "views/menu.xml",

--- a/product_blueprint_manager/views/product_blueprint_condition_views.xml
+++ b/product_blueprint_manager/views/product_blueprint_condition_views.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id="view_product_blueprint_condition_tree" model="ir.ui.view">
+        <field name="name">product.blueprint.condition.tree</field>
+        <field name="model">product.blueprint.condition</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="attribute_id"/>
+                <field name="value_ids" widget="many2many_tags"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_product_blueprint_condition_form" model="ir.ui.view">
+        <field name="name">product.blueprint.condition.form</field>
+        <field name="model">product.blueprint.condition</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="attribute_id"/>
+                        <field name="value_ids" widget="many2many_tags"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/product_blueprint_manager/views/product_views.xml
+++ b/product_blueprint_manager/views/product_views.xml
@@ -32,11 +32,12 @@
                                     </group>
                                     <group string="Configuración del Plano">
                                         <field name="type_blueprint" />
-                                        <field name="attribute_filter_id" />
-                                        <field
-                      name="attribute_value_ids"
-                      widget="many2many_tags"
-                    />
+                                        <field name="blueprint_condition_ids">
+                                            <tree editable="bottom">
+                                                <field name="attribute_id"/>
+                                                <field name="value_ids" widget="many2many_tags"/>
+                                            </tree>
+                                        </field>
                                     </group>
                                 </sheet>
                             </form>


### PR DESCRIPTION
## Summary
- remove attribute filter fields from blueprint form view and add inline condition editor
- add tree and form views for product blueprint conditions
- load new views in module manifest

## Testing
- `pre-commit run --files product_blueprint_manager/views/product_views.xml product_blueprint_manager/views/product_blueprint_condition_views.xml product_blueprint_manager/__manifest__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_689366882804832f8d606eb6b9827091