### PR TITLE
Fix blueprint condition evaluation for attribute values

### DIFF
--- a/product_blueprint_manager/models/sale_order_line.py
+++ b/product_blueprint_manager/models/sale_order_line.py
@@ -409,7 +409,7 @@ class SaleOrderLine(models.Model):
 
             skip_blueprint = False
             for condition in blueprint.blueprint_condition_ids:
-                required = set(condition.attribute_value_ids.mapped("name"))
+                required = set(condition.value_ids.mapped("name"))
                 selected = attribute_values.get(condition.attribute_id.id, set())
                 if required and selected.isdisjoint(required):
                     _logger.debug(


### PR DESCRIPTION
## Summary
- use `value_ids` instead of deprecated `attribute_value_ids` when filtering blueprints

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pre-commit run --files product_blueprint_manager/models/sale_order_line.py`


------
https://chatgpt.com/codex/tasks/task_e_68936f39dc30832f9e297d0ce29dea93