### PR TITLE
fix duplicate blueprint view reference

### DIFF
--- a/product_blueprint_manager/__manifest__.py
+++ b/product_blueprint_manager/__manifest__.py
@@ -25,7 +25,6 @@
         "views/product_blueprint_condition_views.xml",
         "views/sale_order_views.xml",
         "views/product_views.xml",
-        "views/product_blueprint_condition_views.xml",
         "views/menu.xml",
         "reports/sale_order_report.xml",
         "reports/purchase_order_report.xml",


### PR DESCRIPTION
## Summary
- remove duplicate blueprint condition view entry from manifest

## Testing
- `pre-commit run --files product_blueprint_manager/__manifest__.py`
- `odoo --addons-path=. -d test -u product_blueprint_manager --stop-after-init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936f3be7e4832f866a09fb2ffb0636