### PR TITLE
refactor blueprint conditions

### DIFF
--- a/product_blueprint_manager/models/product_blueprint.py
+++ b/product_blueprint_manager/models/product_blueprint.py
@@ -42,24 +42,10 @@ class ProductBlueprint(models.Model):
         ),
     )
 
-    attribute_filter_id = fields.Many2one(
-        "product.attribute",
-        string="Atributo Condicional",
-        help=(
-            "Atributo del producto que se debe usar para condicionar "
-            "este plano. "
-            "Si no se define, el plano siempre aplica."
-        ),
-    )
-
-    attribute_value_ids = fields.Many2many(
-        "product.attribute.value",
-        string="Valores que activan este plano",
-        domain="[('attribute_id', '=', attribute_filter_id)]",
-        help=(
-            "Valores del atributo que deben estar presentes para que "
-            "este plano se aplique."
-        ),
+    blueprint_condition_ids = fields.One2many(
+        "product.blueprint.condition",
+        "blueprint_id",
+        string="Conditions",
     )
 
     def _extract_svg_formulas(self):

--- a/product_blueprint_manager/models/sale_order_line.py
+++ b/product_blueprint_manager/models/sale_order_line.py
@@ -409,7 +409,7 @@ class SaleOrderLine(models.Model):
 
             skip_blueprint = False
             for condition in blueprint.blueprint_condition_ids:
-                required = set(condition.attribute_value_ids.mapped("name"))
+                required = set(condition.value_ids.mapped("name"))
                 selected = attribute_values.get(condition.attribute_id.id, set())
                 if required and selected.isdisjoint(required):
                     _logger.debug(


### PR DESCRIPTION
## Summary
- replace legacy attribute fields with blueprint_condition_ids on product.blueprint
- adjust sale order line logic to read condition values

## Testing
- `python -m py_compile product_blueprint_manager/models/product_blueprint.py product_blueprint_manager/models/sale_order_line.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pip install odoo` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68936f379b44832fad2a22e79e0dea70