### PR TITLE
[IMP] product_blueprint_manager: vistas listas para Blueprints y Fórm…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Cada módulo mantiene su propio `README.md` con detalles específicos.
 Este proyecto sigue el flujo de trabajo recomendado por la **OCA**:
 
 - `16.0`: versión estable para Odoo 16.
-- `17.0`: versión estable y **rama principal de desarrollo** (Odoo 17).
-- `18.0`: versión para Odoo 18 (migrada desde `17.0`).
+- `17.0`: versión estable para Odoo 17. 
+- `18.0`: versión para Odoo 18 y **rama principal de desarrollo** (Odoo 18).
 
 > **Nota:** No existe rama `develop`. Los cambios se realizan directamente en la rama correspondiente a la versión de Odoo (normalmente `17.0`) y, si es necesario, se portan a otras ramas.
 

--- a/product_blueprint_manager/__manifest__.py
+++ b/product_blueprint_manager/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Product Blueprint Manager",
-    "version": "17.0.10.1.3",
+    "version": "17.0.10.1.4",
     "category": "Manufacturing",
     "summary": (
         "Gestione planos de productos y genere documentos de forma dinámica. "
@@ -24,6 +24,8 @@
         "views/product_blueprint_condition_views.xml",
         "views/sale_order_views.xml",
         "views/product_views.xml",
+        "views/product_blueprint_views.xml",
+        "views/product_blueprint_formula_views.xml",
         "views/menu.xml",
         "reports/sale_order_report.xml",
         "reports/purchase_order_report.xml",

--- a/product_blueprint_manager/views/__init__.py
+++ b/product_blueprint_manager/views/__init__.py
@@ -2,6 +2,8 @@ from . import (
     blueprint_report_template,
     menu_views,
     product_views,
+    product_blueprint_views,
+    product_blueprint_formula_views,
     product_blueprint_condition_views,
     sale_order_views,
     sale_report_blueprint_final,

--- a/product_blueprint_manager/views/product_blueprint_condition_views.xml
+++ b/product_blueprint_manager/views/product_blueprint_condition_views.xml
@@ -21,11 +21,11 @@
         <field name="name">product.blueprint.condition.tree</field>
         <field name="model">product.blueprint.condition</field>
         <field name="arch" type="xml">
-            <list string="Condiciones de Plano">
+            <tree>
                 <field name="blueprint_id" />
                 <field name="attribute_id" />
                 <field name="value_ids" />
-            </list>
+            </tree>
         </field>
     </record>
 

--- a/product_blueprint_manager/views/product_blueprint_formula_views.xml
+++ b/product_blueprint_manager/views/product_blueprint_formula_views.xml
@@ -1,0 +1,33 @@
+<odoo>
+    <record id="view_product_blueprint_formula_list" model="ir.ui.view">
+        <field name="name">product.blueprint.formula.list</field>
+        <field name="model">product.blueprint.formula</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="product_id" />
+                <field name="blueprint_id" />
+                <field name="formula_expression" />
+                <field name="fill_color" optional="hide" />
+                <field name="font_size" optional="hide" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- Hacer que esta vista list sea la principal de la acción del menú -->
+    <record
+    id="product_blueprint_formula_action_view_list"
+    model="ir.actions.act_window.view"
+  >
+        <field
+      name="act_window_id"
+      ref="product_blueprint_manager.product_blueprint_formula_action"
+    />
+        <field name="view_mode">tree</field>
+        <field
+      name="view_id"
+      ref="product_blueprint_manager.view_product_blueprint_formula_list"
+    />
+        <field name="sequence">1</field>
+    </record>
+</odoo>

--- a/product_blueprint_manager/views/product_blueprint_views.xml
+++ b/product_blueprint_manager/views/product_blueprint_views.xml
@@ -1,0 +1,30 @@
+<odoo>
+    <record id="view_product_blueprint_list" model="ir.ui.view">
+        <field name="name">product.blueprint.list</field>
+        <field name="model">product.blueprint</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="product_id" />
+                <field name="type_blueprint" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- Vincular esta vista list a la acción del menú para que sea la principal -->
+    <record
+    id="product_blueprint_action_view_list"
+    model="ir.actions.act_window.view"
+  >
+        <field
+      name="act_window_id"
+      ref="product_blueprint_manager.product_blueprint_action"
+    />
+        <field name="view_mode">tree</field>
+        <field
+      name="view_id"
+      ref="product_blueprint_manager.view_product_blueprint_list"
+    />
+        <field name="sequence">1</field>
+    </record>
+</odoo>


### PR DESCRIPTION
…ulas

- Se añade nueva vista de lista para Blueprints que muestra:
  * Nombre del plano
  * Producto asociado
  * Tipo de plano

- Se añade nueva vista de lista para Fórmulas que muestra:
  * Nombre de la fórmula
  * Producto asociado
  * Plano asociado
  * Expresión de la fórmula
  * Estilos de color y fuente (opcionales)

- Se actualiza el manifest para cargar las nuevas vistas y se incrementa la versión a 18.0.10.1.4
- Se ajusta el __init__.py de views para incluir las nuevas vistas

(cherry picked from commit ac7c035454399f93bb22abb617eaa8e401933bef)